### PR TITLE
Added a binding method

### DIFF
--- a/src/components/CounterClass/index.js
+++ b/src/components/CounterClass/index.js
@@ -8,14 +8,26 @@ export default class CounterClass extends Component {
     this.state = {
       count: 0,
     };
+
+
+    //How to bind eventHandlers(// This binding is necessary to make `this` work in the callback)
+    this.handleAddCount = this.handleAddCount.bind(this)
+    // this.handleMinusCount = this.handleMinusCount.bind(this)
   }
 
-  handleAddCount = () => {
-    this.setState((prevState) => ({ count: prevState.count + 1 }));
-  };
+  //This syntax requires a binding method, prefarably in the constructor as per the REACT documentation.
+  handleAddCount(){
+    this.setState((prevState) => ({
+      count: prevState.count -1
+    }))
+    console.log(this);
 
+  }
+
+  //Using an arrow function is also a binding method!! No need to bind it inside the constructor
   handleMinusCount = () => {
     this.setState((prevState) => ({ count: prevState.count - 1 }));
+
   };
 
   render() {


### PR DESCRIPTION
<h1 align="center">Handling events (Binding)</h1>
<p>Just created a binding method to one of the event methods (handleAddCount method).</p>
<p>Apparently there are around 4 binding methods, binding is not a React Specific behaviour but generally JavaScript.</p>
<li>Most preferred is binding inside the constructor, as per the <a href="https://reactjs.org/docs/handling-events.html">documentation</a></li>
<li>The other method is using the arrow function for the method as you did.</li>
<p>I only edited one method so as you can see the difference. You can read about handling events <a href="https://reactjs.org/docs/handling-events.html">here.</a>I put the comments there for reference purposes.</p>

<h2><em>First ever contribution🤪Let's get things done!🥂</em></h2>